### PR TITLE
Reorder the OCSP and TSA requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # pyasice Changelog
 
+## v.1.0.1
+
+* Reordered requests to OCSP and TSA in the `utils.finalize_signature` function.
+  That was necessary for Esteid services because sometimes the signed container could not be verified,
+  due to an error:
+  ```
+  TimeStamp time is greater than OCSP producedAt TS: 2020-11-05T15:27:59Z OCSP: 20201105152758Z
+  ``` 
+
 ## v.1.0
 
 * Initial version. Supports creating and validating XAdES signatures with Estonian ID services. 

--- a/pyasice/__init__.py
+++ b/pyasice/__init__.py
@@ -18,4 +18,4 @@ from .xmlsig import XmlSignature
 # simply: except pyasice.Error
 Error = PyAsiceError
 
-__version__ = "1.0"
+__version__ = "1.0.1"

--- a/pyasice/utils.py
+++ b/pyasice/utils.py
@@ -22,13 +22,6 @@ def finalize_signature(xml_signature: XmlSignature, issuer_cert: bytes, lt_ts=Tr
 
     subject_cert = xml_signature.get_certificate()
 
-    # Get an OCSP status confirmation
-    ocsp = OCSP(ocsp_url)
-    ocsp.validate(subject_cert, issuer_cert, signature_value)
-
-    # Embed the OCSP response
-    xml_signature.set_ocsp_response(ocsp)
-
     if lt_ts:
         # Get a signature TimeStamp
         tsa = TSA(tsa_url)
@@ -36,3 +29,10 @@ def finalize_signature(xml_signature: XmlSignature, issuer_cert: bytes, lt_ts=Tr
         xml_signature.set_timestamp_response(tsr)
     else:
         xml_signature.remove_timestamp_node()
+
+    # Get an OCSP status confirmation
+    ocsp = OCSP(ocsp_url)
+    ocsp.validate(subject_cert, issuer_cert, signature_value)
+
+    # Embed the OCSP response
+    xml_signature.set_ocsp_response(ocsp)


### PR DESCRIPTION
Problem: sometimes the digidoc tool complains that:
```
TimeStamp time is greater than OCSP producedAt TS: 2020-11-05T15:54:22Z OCSP: 20201105155421Z
```

Assuming TimeStamp time must be less than or equal to OCSP time, let's perform the TSA request before the OCSP request.

Version: 1.0.1