### PR TITLE
Version 1.0.2: Fix an issue with `Container` and `ZipFile` in Python pre-3.8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ ipython_config.py
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # pyasice Changelog
 
+## v.1.0.2
+
+* Fixed an issue with `Container` and `ZipFile` in Python pre-3.8.
+
+  When the name of a file added to container contained a non-ASCII character,
+  a consequent `read()` of this file failed with an error:
+  ```
+  zipfile.BadZipFile: File name in directory 'FILE' and header b'FILE' differ.
+  ```
+  After closing the ZipFile, reading files was OK.
+  
+  As a solution, now the container is opened in read-only mode and all write operations
+  are performed after closing the read-only zipfile, opening it in append mode and
+  closing it again.
+  
+* Added a public property `zip_file` to the `Container` instance which uses a cached
+  read only zip file handle, opening it if necessary.
+
+* Added a public property `zip_writer` to the `Container` instance which opens 
+  an appendable zip file handle, clearing the `zip_file` cache.
+  
+* Merged the `verify_container` and `_verify_container_contents` methods
+  because the latter made little sense on its own as a private method.
+  
+* Replaced `_add_mimetype()` with `_create_container()` which creates and initializes
+  the buffer in one single place.
+
 ## v.1.0.1
 
 * Reordered requests to OCSP and TSA in the `utils.finalize_signature` function.

--- a/pyasice/__init__.py
+++ b/pyasice/__init__.py
@@ -18,4 +18,4 @@ from .xmlsig import XmlSignature
 # simply: except pyasice.Error
 Error = PyAsiceError
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"

--- a/pyasice/tests/conftest.py
+++ b/pyasice/tests/conftest.py
@@ -71,6 +71,11 @@ def certificate_rsa(private_key_rsa) -> Certificate:
     return cert_builder(private_key_rsa)
 
 
+@pytest.fixture()
+def certificate_rsa_bytes(certificate_rsa) -> bytes:
+    return certificate_rsa.public_bytes(Encoding.DER)
+
+
 def generate_xml_signature(certificate: Certificate, signature_algo=None):
     return (
         XmlSignature.create()

--- a/pyasice/tests/test_container.py
+++ b/pyasice/tests/test_container.py
@@ -1,7 +1,10 @@
+import io
 import os
 from tempfile import NamedTemporaryFile
 
 import pytest
+
+from oscrypto.asymmetric import load_certificate
 
 from pyasice import Container, XmlSignature
 
@@ -15,6 +18,26 @@ def temporary_file():
     os.unlink(f.name)
 
 
+def test_container_init__from_file(signed_container_file):
+    bdoc_file = Container(signed_container_file)
+    assert bdoc_file.data_file_names
+
+
+def test_container_init__from_bytes_io(signed_container_file):
+    bdoc_file = Container(io.BytesIO(signed_container_file.read()))
+    assert bdoc_file.data_file_names
+
+
+def test_container_init__from_empty(signed_container_file):
+    with pytest.raises(Container.Error, match="not a valid zip file"):
+        Container(io.BytesIO())
+
+
+def test_container_init__from_non_readable(signed_container_file):
+    with pytest.raises(TypeError, match="Failed to open stream"):
+        Container("text")
+
+
 def test_bdoc_open_save(temporary_file):
     with Container() as bdoc_file:
         bdoc_file.save(temporary_file)
@@ -24,7 +47,7 @@ def test_bdoc_open_save(temporary_file):
         assert e.match("container is closed")
 
     with pytest.raises(Container.Error):
-        bdoc_file.data_file_names  # noqa
+        bdoc_file.open_file("test.txt")
         assert e.match("container is closed")
 
     with Container.open(temporary_file) as bdoc_file:
@@ -32,7 +55,7 @@ def test_bdoc_open_save(temporary_file):
         assert bdoc_file.data_file_names == ["test.txt"]
 
     with pytest.raises(Container.Error):
-        bdoc_file.data_file_names  # noqa
+        bdoc_file.open_file("test.txt")
         assert e.match("container is closed")
 
 
@@ -66,6 +89,19 @@ def test_bdoc_data_files(temporary_file):
         assert f.read() == b"another test"
 
 
+def test_bdoc_data_files_unicode(temporary_file):
+    filename = "test-АБВГДЕЖЗ-ÄÜÕÖ£€.txt"
+    bdoc_file = Container()
+    bdoc_file.add_file(filename, b"test", "text/plain")
+
+    assert bdoc_file.data_file_names == [filename]
+    assert list(bdoc_file.iter_data_files()) == [(filename, b"test", "text/plain")]
+
+    bdoc_file.save(temporary_file)
+    bdoc_file = Container.open(temporary_file)
+    assert bdoc_file.data_file_names == [filename]
+
+
 def test_bdoc_signatures(temporary_file):
     bdoc_file = Container()
     bdoc_file.add_file("test.txt", b"this is a test", "text/plain")
@@ -75,14 +111,14 @@ def test_bdoc_signatures(temporary_file):
     xml_sig = XmlSignature.create().set_signature_value(b"signature")
     bdoc_file.add_signature(xml_sig)
 
-    assert bdoc_file._enumerate_signatures() == ["META-INF/signatures1.xml"]
+    assert bdoc_file.signature_file_names == ["META-INF/signatures1.xml"]
     assert [sig.get_signature_value() for sig in bdoc_file.iter_signatures()] == [b"signature"]
 
     bdoc_file.save(temporary_file)
 
     # Open anew
     bdoc_file = Container.open(temporary_file)
-    assert bdoc_file._enumerate_signatures() == ["META-INF/signatures1.xml"]
+    assert bdoc_file.signature_file_names == ["META-INF/signatures1.xml"]
     assert [sig.get_signature_value() for sig in bdoc_file.iter_signatures()] == [b"signature"]
 
     xml_sig = XmlSignature.create().set_signature_value(b"signature2")
@@ -96,11 +132,11 @@ def test_bdoc_signatures(temporary_file):
 def test_bdoc_signature_numbers():
     bdoc_file = Container()
     bdoc_file.add_file("test.txt", b"this is a test", "text/plain")
-    bdoc_file._zip_file.writestr("META-INF/signatures111.xml", b"dummy")
+    bdoc_file.zip_writer.writestr("META-INF/signatures111.xml", b"dummy")
     xml_sig = XmlSignature.create().set_signature_value(b"signature")
     bdoc_file.add_signature(xml_sig)
 
-    assert bdoc_file._enumerate_signatures() == ["META-INF/signatures111.xml", "META-INF/signatures112.xml"]
+    assert bdoc_file.signature_file_names == ["META-INF/signatures111.xml", "META-INF/signatures112.xml"]
 
 
 def test_bdoc_finalize(temporary_file, xml_signature_rsa_signed):
@@ -110,8 +146,27 @@ def test_bdoc_finalize(temporary_file, xml_signature_rsa_signed):
 
     bdoc_file2 = Container(buffer)
 
-    assert bdoc_file2._enumerate_signatures() == ["META-INF/signatures1.xml"]
+    assert bdoc_file2.signature_file_names == ["META-INF/signatures1.xml"]
     assert bdoc_file2.data_file_names == ["test.txt"]
 
     bdoc_file2.verify_signatures()
     assert "No exception was raised"
+
+
+@pytest.mark.parametrize("cert_type", ["bytes", "oscrypto.Certificate"])
+def test_bdoc_prepare_signature(certificate_rsa_bytes, cert_type):
+    bdoc_file = Container()
+
+    if cert_type == "bytes":
+        certificate = certificate_rsa_bytes
+    else:
+        certificate = load_certificate(certificate_rsa_bytes)
+
+    with pytest.raises(Container.NoFilesToSign):
+        bdoc_file.prepare_signature(certificate)
+
+    bdoc_file.add_file("test.txt", b"test", "text.plain")
+    result = bdoc_file.prepare_signature(certificate)
+    assert isinstance(result, XmlSignature)
+
+    assert result.get_certificate_value() == certificate_rsa_bytes

--- a/pyasice/tests/test_xml_signature.py
+++ b/pyasice/tests/test_xml_signature.py
@@ -7,7 +7,6 @@ import pytest
 
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, padding
-from cryptography.hazmat.primitives.serialization import Encoding
 from lxml import etree
 from oscrypto.asymmetric import Certificate, load_certificate
 
@@ -63,13 +62,13 @@ def test_xmlsig_signing_time():
     assert xml_signature.get_signing_time() == "2000-01-01T00:00:00Z"
 
 
-def test_xmlsig_certificate(certificate_rsa):
+def test_xmlsig_certificate(certificate_rsa_bytes):
     xml_signature = XmlSignature.create()
 
     assert xml_signature.get_certificate_value() is None
     assert xml_signature.get_certificate() is None
 
-    cert = load_certificate(certificate_rsa.public_bytes(Encoding.DER))
+    cert = load_certificate(certificate_rsa_bytes)
 
     xml_signature.set_certificate(cert)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,11 +10,13 @@ exclude =
     old,
     build,
     dist,
-    venv*
+    venv*,
+    .venv*
 
 [tool:isort]
 skip_glob=
-  venv/*
+  venv*
+  .venv*
   migrations
 line_length=120
 atomic=true


### PR DESCRIPTION
  When the name of a file added to container contained a non-ASCII character,
  a consequent `read()` of this file failed with an error:
  ```
  zipfile.BadZipFile: File name in directory 'FILE' and header b'FILE' differ.
  ```
  After closing the ZipFile, reading files was OK.

  As a solution, now the container is opened in read-only mode and all write operations
  are performed after closing the read-only zipfile, opening it in append mode and
  closing it again.

Also:
* Added a public property `zip_file` to the `Container` instance which uses a cached
  read only zip file handle, opening it if necessary.

* Added a public property `zip_writer` to the `Container` instance which opens
  an appendable zip file handle, clearing the `zip_file` cache.

* Merged the `verify_container` and `_verify_container_contents` methods
  because the latter made little sense on its own as a private method.

* Replaced `_add_mimetype()` with `_create_container()` which creates and initializes
  the buffer in one single place.