### PR TITLE
Added compatibility with Latvian edoc format

### DIFF
--- a/pyasice/templates/signature.xml
+++ b/pyasice/templates/signature.xml
@@ -65,9 +65,9 @@
                 </xades:SignedProperties>
                 <xades:UnsignedProperties>
                     <xades:UnsignedSignatureProperties>
-                        <xades:SignatureTimeStamp>
+                        <xades:SignatureTimeStamp Id="TS">
                             <ds:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
-                            <xades:EncapsulatedTimeStamp>
+                            <xades:EncapsulatedTimeStamp Id="ETS">
                                 <!-- response from the timestamping service -->
                             </xades:EncapsulatedTimeStamp>
                         </xades:SignatureTimeStamp>

--- a/pyasice/tests/test_xml_signature.py
+++ b/pyasice/tests/test_xml_signature.py
@@ -70,6 +70,16 @@ def test_xmlsig_add_cert(certificate_rsa_bytes):
     assert xml_signature._get_node("xades:EncapsulatedX509Certificate").attrib["Id"] == "TEST-ID"
 
 
+def test_xmlsig_add_cert_without_attrib(certificate_rsa_bytes):
+    xml_signature = XmlSignature.create()
+
+    cert = load_certificate(certificate_rsa_bytes)
+    xml_signature.add_cert(cert)
+    assert xml_signature._get_node("xades:EncapsulatedX509Certificate").text == base64.b64encode(
+        cert.asn1.dump()
+    ).decode("ascii")
+
+
 def test_xmlsig_set_root_cert(certificate_rsa_bytes):
     xml_signature = XmlSignature.create()
 

--- a/pyasice/tests/test_xml_signature.py
+++ b/pyasice/tests/test_xml_signature.py
@@ -61,19 +61,24 @@ def test_xmlsig_signing_time():
 
     assert xml_signature.get_signing_time() == "2000-01-01T00:00:00Z"
 
+
 def test_xmlsig_add_cert(certificate_rsa_bytes):
     xml_signature = XmlSignature.create()
 
     cert = load_certificate(certificate_rsa_bytes)
-    xml_signature.add_cert(cert, {'Id': 'TEST-ID'})
-    assert xml_signature._get_node('xades:EncapsulatedX509Certificate').attrib["Id"] == 'TEST-ID'
+    xml_signature.add_cert(cert, {"Id": "TEST-ID"})
+    assert xml_signature._get_node("xades:EncapsulatedX509Certificate").attrib["Id"] == "TEST-ID"
+
 
 def test_xmlsig_set_root_cert(certificate_rsa_bytes):
     xml_signature = XmlSignature.create()
 
     cert = load_certificate(certificate_rsa_bytes)
     xml_signature.set_root_ca_cert(cert)
-    assert xml_signature._get_node('xades:EncapsulatedX509Certificate').attrib["Id"] == f'{xml_signature.NEW_SIGNATURE_ID}-ROOT-CA-CERT'
+    assert (
+        xml_signature._get_node("xades:EncapsulatedX509Certificate").attrib["Id"]
+        == f"{xml_signature.NEW_SIGNATURE_ID}-ROOT-CA-CERT"
+    )
 
 
 def test_xmlsig_certificate(certificate_rsa_bytes):

--- a/pyasice/tests/test_xml_signature.py
+++ b/pyasice/tests/test_xml_signature.py
@@ -61,6 +61,20 @@ def test_xmlsig_signing_time():
 
     assert xml_signature.get_signing_time() == "2000-01-01T00:00:00Z"
 
+def test_xmlsig_add_cert(certificate_rsa_bytes):
+    xml_signature = XmlSignature.create()
+
+    cert = load_certificate(certificate_rsa_bytes)
+    xml_signature.add_cert(cert, {'Id': 'TEST-ID'})
+    assert xml_signature._get_node('xades:EncapsulatedX509Certificate').attrib["Id"] == 'TEST-ID'
+
+def test_xmlsig_set_root_cert(certificate_rsa_bytes):
+    xml_signature = XmlSignature.create()
+
+    cert = load_certificate(certificate_rsa_bytes)
+    xml_signature.set_root_ca_cert(cert)
+    assert xml_signature._get_node('xades:EncapsulatedX509Certificate').attrib["Id"] == f'{xml_signature.NEW_SIGNATURE_ID}-ROOT-CA-CERT'
+
 
 def test_xmlsig_certificate(certificate_rsa_bytes):
     xml_signature = XmlSignature.create()

--- a/pyasice/xmlsig.py
+++ b/pyasice/xmlsig.py
@@ -330,23 +330,22 @@ class XmlSignature:
 
         :param root_cert: can be a PEM- or DER-encoded bytes content, or an `oscrypto.Certificate` object
         """
-        certs_node = self._get_node("xades:CertificateValues")
-        ca_node = etree.Element("{%s}EncapsulatedX509Certificate" % self.NAMESPACES["xades"])
-        ca_node.attrib["Id"] = "%s-ROOT-CA-CERT" % self.NEW_SIGNATURE_ID
-        if not isinstance(root_cert, Certificate):
-            root_cert = load_certificate(root_cert)
-        ca_node.text = base64.b64encode(root_cert.asn1.dump())
-        certs_node.append(ca_node)
+        self.add_cert(root_cert, {"Id": f"{self.NEW_SIGNATURE_ID}-ROOT-CA-CERT"})
         return self
 
-    def add_cert(self, cert: Union[Certificate, bytes]) -> "XmlSignature":
+    def add_cert(self, cert: Union[Certificate, bytes], attrib: Optional[dict]) -> "XmlSignature":
         """Add a cert. Latvian EDOC must have all of certs used in the xml (Root, OCSP and TimeStamp)
            This is mandatory for Latvian EDOC format
 
         :param cert: can be a PEM- or DER-encoded bytes content, or an `oscrypto.Certificate` object
+        :param attrib: dict with attributes for <EncapsulatedX509Certificate> tag
         """
         certs_node = self._get_node("xades:CertificateValues")
         ca_node = etree.Element("{%s}EncapsulatedX509Certificate" % self.NAMESPACES["xades"])
+
+        for name, value in attrib.items():
+            ca_node.attrib[name] = value
+
         if not isinstance(cert, Certificate):
             cert = load_certificate(cert)
         ca_node.text = base64.b64encode(cert.asn1.dump())

--- a/pyasice/xmlsig.py
+++ b/pyasice/xmlsig.py
@@ -339,6 +339,20 @@ class XmlSignature:
         certs_node.append(ca_node)
         return self
 
+    def add_cert(self, cert: Union[Certificate, bytes]) -> "XmlSignature":
+        """Add a cert. Latvian EDOC must have all of certs used in the xml (Root, OCSP and TimeStamp)
+           This is mandatory for Latvian EDOC format
+
+        :param cert: can be a PEM- or DER-encoded bytes content, or an `oscrypto.Certificate` object
+        """
+        certs_node = self._get_node("xades:CertificateValues")
+        ca_node = etree.Element("{%s}EncapsulatedX509Certificate" % self.NAMESPACES["xades"])
+        if not isinstance(cert, Certificate):
+            cert = load_certificate(cert)
+        ca_node.text = base64.b64encode(cert.asn1.dump())
+        certs_node.append(ca_node)
+        return self
+
     def set_ocsp_response(self, ocsp_response: OCSP, embed_ocsp_certificate=False) -> "XmlSignature":
         """
         Embed the OCSP response and certificates

--- a/pyasice/xmlsig.py
+++ b/pyasice/xmlsig.py
@@ -3,8 +3,9 @@ import copy
 import hashlib
 import logging
 import os
+
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional, Union, Dict
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -333,7 +334,7 @@ class XmlSignature:
         self.add_cert(root_cert, {"Id": f"{self.NEW_SIGNATURE_ID}-ROOT-CA-CERT"})
         return self
 
-    def add_cert(self, cert: Union[Certificate, bytes], attrib: Optional[dict]) -> "XmlSignature":
+    def add_cert(self, cert: Union[Certificate, bytes], attrib: Dict = {}) -> "XmlSignature":
         """Add a cert. Latvian EDOC must have all of certs used in the xml (Root, OCSP and TimeStamp)
            This is mandatory for Latvian EDOC format
 

--- a/pyasice/xmlsig.py
+++ b/pyasice/xmlsig.py
@@ -3,9 +3,8 @@ import copy
 import hashlib
 import logging
 import os
-
 from datetime import datetime
-from typing import Optional, Union, Dict
+from typing import Dict, Optional, Union
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend

--- a/pyasice/xmlsig.py
+++ b/pyasice/xmlsig.py
@@ -333,7 +333,7 @@ class XmlSignature:
         self.add_cert(root_cert, {"Id": f"{self.NEW_SIGNATURE_ID}-ROOT-CA-CERT"})
         return self
 
-    def add_cert(self, cert: Union[Certificate, bytes], attrib: Dict = {}) -> "XmlSignature":
+    def add_cert(self, cert: Union[Certificate, bytes], attribs: Optional[Dict] = None) -> "XmlSignature":
         """Add a cert. Latvian EDOC must have all of certs used in the xml (Root, OCSP and TimeStamp)
            This is mandatory for Latvian EDOC format
 
@@ -343,8 +343,9 @@ class XmlSignature:
         certs_node = self._get_node("xades:CertificateValues")
         ca_node = etree.Element("{%s}EncapsulatedX509Certificate" % self.NAMESPACES["xades"])
 
-        for name, value in attrib.items():
-            ca_node.attrib[name] = value
+        if attribs is not None:
+            for name, value in attribs.items():
+                ca_node.attrib[name] = value
 
         if not isinstance(cert, Certificate):
             cert = load_certificate(cert)


### PR DESCRIPTION
ID attribute is required for `SignatureTimeStamp` tag.
Each of used certificate (CA root, OCSP and TS) must be added to `CertificateValues` tag.

What do you think about `add_cert ` method which not so DRY on `set_root_ca_cert` point of view?